### PR TITLE
fix(fitvts/cts): Remove "days" when computing dt in fitvts to prevent…

### DIFF
--- a/toolbox/+baseflow/fitevents.m
+++ b/toolbox/+baseflow/fitevents.m
@@ -152,7 +152,8 @@ end
 function [q, dqdt, dt, tq, ok] = preparefit(q, dqdt, dt, tq, thisfit)
 
    % if there are multiple fits for an event, qHat, dHat, etc. will be cell
-   % arrays. this pulls out the selected values to fit.
+   % arrays. this pulls out the selected values to fit. Otherwise, it simply
+   % returns the inputs as outputs.
 
    if iscell(q)
       q = q{thisfit};
@@ -195,7 +196,7 @@ function [Fits, K, fitcount] = saveFit(T, q, dqdt, dt, tq, derivmethod, ...
 
 
       % collect all data for the point-cloud
-      fitIdx = ismember(T,tq);
+      fitIdx = ismember(T, tq);
       %fitIdx = ismember(T,datenum(tq)); % TEST
       Fits.q(        fitIdx) = q;
       Fits.dqdt(     fitIdx) = dqdt;

--- a/toolbox/+baseflow/private/fitcts.m
+++ b/toolbox/+baseflow/private/fitcts.m
@@ -25,20 +25,20 @@ function [q,dqdt,dt,tq,rq,dq] = fitcts(T,Q,R,varargin)
    Tip1    = [Ti(2:end); nan];         % i plus 1
 
    % % forward, backward, and centered mean flow
-   dt      = (T(2)-T(1)).*ones(size(T));
+   dt      = (T(2)-T(1)) * ones(size(T));
    % Qfwd    = (Qi+Qip1)./2./dt;
    % Qbwd    = (Qi+Qim1)./2./dt;
    % Qctr    = (Qip1+Qim1)./2./dt;
 
    % not sure why the /dt's are above, maybe before I did dqdt = dq/dt
    % at the end (since those values are the average flow over two steps)
-   Qfwd    = (Qi+Qip1)./2;
-   Qbwd    = (Qi+Qim1)./2;
-   Qctr    = (Qip1+Qim1)./2;
+   Qfwd    = (Qi+Qip1) / 2;
+   Qbwd    = (Qi+Qim1) / 2;
+   Qctr    = (Qip1+Qim1) / 2;
 
-   Tbwd    = (Ti+Tim1)./2;                     % new
-   Tfwd    = (Ti+Tip1)./2;
-   Tctr    = (Tip1+Tim1)./2;
+   Tbwd    = (Ti+Tim1) / 2;                     % new
+   Tfwd    = (Ti+Tip1) / 2;
+   Tctr    = (Tip1+Tim1) / 2;
 
    switch method
       case 'B1'                                 % backward, version 1
@@ -46,7 +46,7 @@ function [q,dqdt,dt,tq,rq,dq] = fitcts(T,Q,R,varargin)
          q   = Qbwd;
          tq  = Tbwd;
       case 'B2'                                 % backward, version 2
-         dq  = (3.*Qi-4.*Qim1+Qim2)./2;
+         dq  = (3*Qi - 4*Qim1 + Qim2) / 2;
          q   = Qbwd;
          tq  = Tbwd;
       case 'F1'                                 % forward, version 1
@@ -54,15 +54,15 @@ function [q,dqdt,dt,tq,rq,dq] = fitcts(T,Q,R,varargin)
          q   = Qfwd;
          tq  = Tfwd;
       case 'F2'                                 % forward, version 2
-         dq  = (-Qip2+4.*Qip1-3.*Qi)./2;
+         dq  = (-Qip2+4 .* Qip1 - 3*Qi) / 2;
          q   = Qfwd;
          tq  = Tfwd;
       case 'C2'                                 % centered, version 1
-         dq  = (Qip1-Qim1)./2;
+         dq  = (Qip1-Qim1) / 2;
          q   = Qctr;
          tq  = Tctr;
       case 'C4'                                 % centered, version 2
-         dq  = (-Qip2+8.*Qip1-8.*Qim1+Qip2)./12;
+         dq  = (-Qip2 + 8*Qip1 - 8*Qim1 + Qip2) / 12;
          q   = Qctr;
          tq  = Tctr;
    end
@@ -70,4 +70,8 @@ function [q,dqdt,dt,tq,rq,dq] = fitcts(T,Q,R,varargin)
 
    rq = []; % TODO
 
+   % Patch: post the estimates on the original time vector. It is unclear
+   % what value should be used, but anything other than the original time
+   % complicates subsequent identification of events.
+   tq = T;
 end

--- a/toolbox/+baseflow/private/fitets.m
+++ b/toolbox/+baseflow/private/fitets.m
@@ -126,6 +126,10 @@ function [q,dqdt,dt,tq,rq,dq] = fitets(T,Q,R,varargin)
    q = interp1(tq(~isnan(q)),q(~isnan(q)),T);
    dq = interp1(tq(~isnan(dq)),dq(~isnan(dq)),T);
    dqdt = interp1(tq(~isnan(dqdt)),dqdt(~isnan(dqdt)),T);
+
+   % Patch: post the estimates on the original time vector. It is unclear
+   % what value should be used, but anything other than the original time
+   % complicates subsequent identification of events.
    tq = T;
 
    if plotfit == true

--- a/toolbox/+baseflow/private/fitvts.m
+++ b/toolbox/+baseflow/private/fitvts.m
@@ -18,6 +18,11 @@ function [q,dqdt,dt,tq,rq,dq] = fitvts(T,Q,R,varargin)
    %     vtsparam : scalar, double, parameter that controls window size
    %     plotfit  : logical, scalar, indicates whether to plot the fit
    %
+   % This code is based on the method described in:
+   % Rupp, D. E. and Selker, J. S.: Information, artifacts, and noise in dQ/dt −
+   % Q recession analysis, Advances in Water Resources, 29, 154–160,
+   % https://doi.org/10.1016/j.advwatres.2005.03.019, 2006.
+   %
    % See also fitdqdt, fitets
    %
    % Matt Cooper, 04-Nov-2022, https://github.com/mgcooper
@@ -31,7 +36,10 @@ function [q,dqdt,dt,tq,rq,dq] = fitvts(T,Q,R,varargin)
    % need e and the stage-discharge relation.
 
    % prep the time vector
-   t = days(T-T(1)+(T(2)-T(1))); % keep og T
+   t = T - T(1) + (T(2)-T(1)); % keep og T
+
+   % For datetimes:
+   % t = days(T-T(1)+(T(2)-T(1))); % keep og T
 
    % initialize the approximations for dq/dt and Q (and dq and dt)
    [N,q,dqdt,dq,dt,tq,rq] = initfit(Q,'eventdqdt');
@@ -71,6 +79,9 @@ function [q,dqdt,dt,tq,rq,dq] = fitvts(T,Q,R,varargin)
    % dq    = interp1(tq(~isnan(dq)),dq(~isnan(dq)),T);
    % dqdt  = interp1(tq(~isnan(dqdt)),dqdt(~isnan(dqdt)),T);
 
+   % Patch: post the estimates on the original time vector. It is unclear
+   % what value should be used, but anything other than the original time
+   % complicates subsequent identification of events.
    tq = T;
 
    if plotfit == true


### PR DESCRIPTION
Remove use of function `days` when computing `dt` in `baseflow.fitvts` to prevent creation of type `duration`.
 
`days` would be correct if `datetime` were used, but datenums are used for Octave compatibility. 

Also reassign `tq` to `T` at the end of `fitcts` so the output event times are the same as the inputs and can be located on the main `eventTime` vector..

Fixes #3, Fixes #7  
